### PR TITLE
Fix issues with both ban commands

### DIFF
--- a/backend/src/plugins/ModActions/commands/BanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/BanCmd.ts
@@ -135,19 +135,7 @@ export const BanCmd = modActionsCmd({
           return;
         }
       } else {
-        // Ask the mod if we should upgrade to a forceban as the user is not on the server
-        const reply = await waitForButtonConfirm(
-          msg.channel,
-          { content: "User not on server, forceban instead?" },
-          { confirmText: "Yes", cancelText: "No", restrictToId: msg.member.id },
-        );
-        if (!reply) {
-          sendErrorMessage(pluginData, msg.channel, "User not on server, ban cancelled by moderator");
-          lock.unlock();
-          return;
-        } else {
-          forceban = true;
-        }
+        forceban = true;
       }
     }
 

--- a/backend/src/plugins/ModActions/commands/ForcebanCmd.ts
+++ b/backend/src/plugins/ModActions/commands/ForcebanCmd.ts
@@ -11,6 +11,10 @@ import { ignoreEvent } from "../functions/ignoreEvent";
 import { isBanned } from "../functions/isBanned";
 import { IgnoredEventType, modActionsCmd } from "../types";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
+import { LogType } from "../../../data/LogType";
+import { CaseTypes } from "../../../data/CaseTypes";
+import { CasesPlugin } from "../../../plugins/Cases/CasesPlugin";
+import { banLock } from "../../../utils/lockNameHelpers";
 
 const opts = {
   mod: ct.member({ option: true }),
@@ -63,18 +67,30 @@ export const ForcebanCmd = modActionsCmd({
     }
 
     const reason = formatReasonWithAttachments(args.reason, [...msg.attachments.values()]);
+    const lock = await pluginData.locks.acquire(banLock(user));
 
     ignoreEvent(pluginData, IgnoredEventType.Ban, user.id);
     pluginData.state.serverLogs.ignoreLog(LogType.MEMBER_BAN, user.id);
 
     try {
-      // FIXME: Use banUserId()?
-      await pluginData.guild.bans.create(user.id as Snowflake, {
-        days: 1,
-        reason: reason ?? undefined,
+      const deleteMessageDays = args["delete-days"] ?? pluginData.config.getForMessage(msg).ban_delete_message_days;
+      const banResult = await banUserId(pluginData, user.id, reason, {
+        contactMethods: [],
+        caseArgs: {
+          modId: mod.id,
+          ppId: mod.id !== msg.author.id ? msg.author.id : undefined,
+        },
+        deleteMessageDays,
+        modId: mod.id,
       });
+      if (banResult.status === "failed") {
+        sendErrorMessage(pluginData, msg.channel, `Failed to ban member: ${banResult.error}`);
+        lock.unlock();
+        return;
+      }
     } catch {
       sendErrorMessage(pluginData, msg.channel, "Failed to forceban member");
+      lock.unlock();
       return;
     }
 
@@ -90,6 +106,7 @@ export const ForcebanCmd = modActionsCmd({
 
     // Confirm the action
     sendSuccessMessage(pluginData, msg.channel, `Member forcebanned (Case #${createdCase.case_number})`);
+    lock.unlock();
 
     // Log the action
     pluginData.getPlugin(LogsPlugin).logMemberForceban({

--- a/backend/src/plugins/ModActions/functions/banUserId.ts
+++ b/backend/src/plugins/ModActions/functions/banUserId.ts
@@ -87,7 +87,7 @@ export async function banUserId(
     const deleteMessageDays = Math.min(30, Math.max(0, banOptions.deleteMessageDays ?? 1));
     // Trim down reason to 490 words, API limit is 512 and we leave a gap to accomodate cross-ban bots
     if (reason && reason.length >= 490) {
-      reason = reason.substring(0, 487) + "...";
+      reason = reason.substring(0, 489) + "…";
     }
     await pluginData.guild.bans.create(userId as Snowflake, {
       days: deleteMessageDays,

--- a/backend/src/plugins/ModActions/functions/banUserId.ts
+++ b/backend/src/plugins/ModActions/functions/banUserId.ts
@@ -87,7 +87,7 @@ export async function banUserId(
     const deleteMessageDays = Math.min(30, Math.max(0, banOptions.deleteMessageDays ?? 1));
     // Trim down reason to 490 words, API limit is 512 and we leave a gap to accomodate cross-ban bots
     if (reason && reason.length >= 490) {
-      reason = reason.substring(0, 200) + "...";
+      reason = reason.substring(0, 487) + "...";
     }
     await pluginData.guild.bans.create(userId as Snowflake, {
       days: deleteMessageDays,

--- a/backend/src/plugins/ModActions/functions/banUserId.ts
+++ b/backend/src/plugins/ModActions/functions/banUserId.ts
@@ -85,6 +85,10 @@ export async function banUserId(
   ignoreEvent(pluginData, IgnoredEventType.Ban, userId);
   try {
     const deleteMessageDays = Math.min(30, Math.max(0, banOptions.deleteMessageDays ?? 1));
+    // Trim down reason to 490 words, API limit is 512 and we leave a gap to accomodate cross-ban bots
+    if (reason && reason.length >= 490) {
+      reason = reason.substring(0, 200) + "...";
+    }
     await pluginData.guild.bans.create(userId as Snowflake, {
       days: deleteMessageDays,
       reason: reason ?? undefined,


### PR DESCRIPTION
- Removes unnecessary check if the user wants to upgrade ban to forceban if target not on server
- Trims down reason to 490 characters. API maximum is 512, and cross-ban bots might add characters onto the reason so I added a small buffer
- Move forceban over to banUserId (as requested in FIXME comment)