### PR TITLE
Reworked automod "set_slowmode" action

### DIFF
--- a/backend/src/plugins/Automod/actions/setSlowmode.ts
+++ b/backend/src/plugins/Automod/actions/setSlowmode.ts
@@ -28,11 +28,13 @@ export const SetSlowmodeAction = automodAction({
       if (
         !channel ||
         !(
-          channel.type === ChannelTypeStrings.TEXT ||
-          ChannelTypeStrings.CATEGORY ||
-          ChannelTypeStrings.PUBLIC_THREAD ||
-          ChannelTypeStrings.NEWS_THREAD ||
-          ChannelTypeStrings.PRIVATE_THREAD
+          [
+            ChannelTypeStrings.TEXT,
+            ChannelTypeStrings.CATEGORY,
+            ChannelTypeStrings.PUBLIC_THREAD,
+            ChannelTypeStrings.NEWS_THREAD,
+            ChannelTypeStrings.PRIVATE_THREAD,
+          ].includes(channel.type)
         )
       ) {
         continue;

--- a/backend/src/plugins/Automod/actions/setSlowmode.ts
+++ b/backend/src/plugins/Automod/actions/setSlowmode.ts
@@ -17,7 +17,7 @@ export const SetSlowmodeAction = automodAction({
 
   async apply({ pluginData, actionConfig, contexts }) {
     const slowmodeMs = Math.max(actionConfig.duration ? convertDelayStringToMS(actionConfig.duration)! : 0, 0);
-    const channels: string[] = actionConfig.channels ?? [];
+    const channels: Snowflake[] = actionConfig.channels ?? [];
     if (channels.length === 0) {
       channels.push(...contexts.filter(c => c.message?.channel_id).map(c => c.message!.channel_id));
     }

--- a/backend/src/plugins/Automod/actions/setSlowmode.ts
+++ b/backend/src/plugins/Automod/actions/setSlowmode.ts
@@ -1,6 +1,6 @@
 import { Snowflake, TextChannel, ThreadChannel } from "discord.js";
 import * as t from "io-ts";
-import { ChannelTypeStrings } from "src/types";
+import { ChannelTypeStrings } from "../../../types";
 import { convertDelayStringToMS, isDiscordAPIError, tDelayString, tNullable } from "../../../utils";
 import { automodAction } from "../helpers";
 import { LogsPlugin } from "../../Logs/LogsPlugin";

--- a/backend/src/plugins/Automod/actions/setSlowmode.ts
+++ b/backend/src/plugins/Automod/actions/setSlowmode.ts
@@ -17,7 +17,7 @@ export const SetSlowmodeAction = automodAction({
 
   async apply({ pluginData, actionConfig, contexts }) {
     const slowmodeMs = Math.max(actionConfig.duration ? convertDelayStringToMS(actionConfig.duration)! : 0, 0);
-    const channels = actionConfig.channels ?? new Array();
+    const channels: string[] = actionConfig.channels ?? [];
     if (channels.length === 0) {
       channels.push(...contexts.filter(c => c.message?.channel_id).map(c => c.message!.channel_id));
     }

--- a/backend/src/plugins/Automod/actions/setSlowmode.ts
+++ b/backend/src/plugins/Automod/actions/setSlowmode.ts
@@ -23,22 +23,8 @@ export const SetSlowmodeAction = automodAction({
     }
     for (const channelId of channels) {
       const channel = pluginData.guild.channels.cache.get(channelId as Snowflake);
-
       // Only text channels and text channels within categories support slowmodes
-      if (
-        !channel ||
-        !(
-          [
-            ChannelTypeStrings.TEXT,
-            ChannelTypeStrings.CATEGORY,
-            ChannelTypeStrings.PUBLIC_THREAD,
-            ChannelTypeStrings.NEWS_THREAD,
-            ChannelTypeStrings.PRIVATE_THREAD,
-          ].includes(channel.type)
-        )
-      ) {
-        continue;
-      }
+      if (!channel?.isText() && channel?.type !== ChannelTypeStrings.CATEGORY) continue;
 
       const channelsToSlowmode: Array<TextChannel | ThreadChannel> = [];
       if (channel.type === ChannelTypeStrings.CATEGORY) {


### PR DESCRIPTION
Now if `channels` is empty or undefined it will set slowmode on the current channel, in terms of functionality I don't think there's any downgrade or loss, however without proper documentation/awareness I imagine this will create issues down the line of people not knowing how this works, similarly to how many other things on the bot are as of right now.

This is mostly for compatibility with #272 