### PR TITLE
Added change_roles automod action

### DIFF
--- a/backend/src/plugins/Automod/AutomodPlugin.ts
+++ b/backend/src/plugins/Automod/AutomodPlugin.ts
@@ -134,6 +134,16 @@ const configPreprocessor: ConfigPreprocessorFn<AutomodPluginType> = options => {
       }
 
       if (rule["actions"]) {
+        if (rule["actions"].change_roles && (rule["actions"].add_roles || rule["actions"].remove_roles)) {
+          throw new StrictValidationError([
+            `Can't use both 'change_roles' and 'add_roles'/'remove_roles' at rule '${rule.name}'`,
+          ]);
+        }
+        if (rule["actions"].add_roles && rule["actions"].remove_roles) {
+          throw new StrictValidationError([
+            `Can't use both 'add_roles' and 'remove_roles' at rule '${rule.name}', use 'change_roles' instead`,
+          ]);
+        }
         for (const actionName in rule["actions"]) {
           if (!availableActions[actionName]) {
             throw new StrictValidationError([`Unknown action '${actionName}' in rule '${rule.name}'`]);

--- a/backend/src/plugins/Automod/AutomodPlugin.ts
+++ b/backend/src/plugins/Automod/AutomodPlugin.ts
@@ -139,11 +139,13 @@ const configPreprocessor: ConfigPreprocessorFn<AutomodPluginType> = options => {
             `Can't use both 'change_roles' and 'add_roles'/'remove_roles' at rule '${rule.name}'`,
           ]);
         }
+
         if (rule["actions"].add_roles && rule["actions"].remove_roles) {
           throw new StrictValidationError([
             `Can't use both 'add_roles' and 'remove_roles' at rule '${rule.name}', use 'change_roles' instead`,
           ]);
         }
+
         for (const actionName in rule["actions"]) {
           if (!availableActions[actionName]) {
             throw new StrictValidationError([`Unknown action '${actionName}' in rule '${rule.name}'`]);

--- a/backend/src/plugins/Automod/AutomodPlugin.ts
+++ b/backend/src/plugins/Automod/AutomodPlugin.ts
@@ -66,24 +66,24 @@ const configPreprocessor: ConfigPreprocessorFn<AutomodPluginType> = options => {
         continue;
       }
 
-      rule["name"] = name;
+      rule.name = name;
 
       // If the rule doesn't have an explicitly set "enabled" property, set it to true
-      if (rule["enabled"] == null) {
-        rule["enabled"] = true;
+      if (rule.enabled == null) {
+        rule.enabled = true;
       }
 
-      if (rule["allow_further_rules"] == null) {
-        rule["allow_further_rules"] = false;
+      if (rule.allow_further_rules == null) {
+        rule.allow_further_rules = false;
       }
 
-      if (rule["affects_bots"] == null) {
-        rule["affects_bots"] = false;
+      if (rule.affects_bots == null) {
+        rule.affects_bots = false;
       }
 
       // Loop through the rule's triggers
-      if (rule["triggers"]) {
-        for (const triggerObj of rule["triggers"]) {
+      if (rule.triggers) {
+        for (const triggerObj of rule.triggers) {
           for (const triggerName in triggerObj) {
             if (!availableTriggers[triggerName]) {
               throw new StrictValidationError([`Unknown trigger '${triggerName}' in rule '${rule.name}'`]);
@@ -152,26 +152,26 @@ const configPreprocessor: ConfigPreprocessorFn<AutomodPluginType> = options => {
           }
 
           const actionBlueprint = availableActions[actionName];
-          const actionConfig = rule["actions"][actionName];
+          const actionConfig = rule.actions[actionName];
 
           if (typeof actionConfig !== "object" || Array.isArray(actionConfig) || actionConfig == null) {
-            rule["actions"][actionName] = actionConfig;
+            rule.actions[actionName] = actionConfig;
           } else {
-            rule["actions"][actionName] = configUtils.mergeConfig(actionBlueprint.defaultConfig, actionConfig);
+            rule.actions[actionName] = configUtils.mergeConfig(actionBlueprint.defaultConfig, actionConfig);
           }
         }
       }
 
       // Enable logging of automod actions by default
-      if (rule["actions"]) {
+      if (rule.actions) {
         for (const actionName in rule.actions) {
           if (!availableActions[actionName]) {
             throw new StrictValidationError([`Unknown action '${actionName}' in rule '${rule.name}'`]);
           }
         }
 
-        if (rule["actions"]["log"] == null) {
-          rule["actions"]["log"] = true;
+        if (rule.actions.log == null) {
+          rule.actions.log = true;
         }
       }
     }

--- a/backend/src/plugins/Automod/AutomodPlugin.ts
+++ b/backend/src/plugins/Automod/AutomodPlugin.ts
@@ -133,20 +133,20 @@ const configPreprocessor: ConfigPreprocessorFn<AutomodPluginType> = options => {
         }
       }
 
-      if (rule["actions"]) {
-        if (rule["actions"].change_roles && (rule["actions"].add_roles || rule["actions"].remove_roles)) {
+      if (rule.actions) {
+        if (rule.actions.change_roles && (rule.actions.add_roles || rule.actions.remove_roles)) {
           throw new StrictValidationError([
             `Can't use both 'change_roles' and 'add_roles'/'remove_roles' at rule '${rule.name}'`,
           ]);
         }
 
-        if (rule["actions"].add_roles && rule["actions"].remove_roles) {
+        if (rule.actions.add_roles && rule.actions.remove_roles) {
           throw new StrictValidationError([
             `Can't use both 'add_roles' and 'remove_roles' at rule '${rule.name}', use 'change_roles' instead`,
           ]);
         }
 
-        for (const actionName in rule["actions"]) {
+        for (const actionName in rule.actions) {
           if (!availableActions[actionName]) {
             throw new StrictValidationError([`Unknown action '${actionName}' in rule '${rule.name}'`]);
           }

--- a/backend/src/plugins/Automod/actions/addRoles.ts
+++ b/backend/src/plugins/Automod/actions/addRoles.ts
@@ -1,6 +1,5 @@
 import { Permissions, Snowflake } from "discord.js";
 import * as t from "io-ts";
-import { LogType } from "../../../data/LogType";
 import { nonNullish, unique } from "../../../utils";
 import { canAssignRole } from "../../../utils/canAssignRole";
 import { getMissingPermissions } from "../../../utils/getMissingPermissions";
@@ -49,6 +48,7 @@ export const AddRolesAction = automodAction({
           "**, **",
         )}**`,
       });
+      return;
     }
 
     await Promise.all(

--- a/backend/src/plugins/Automod/actions/addRoles.ts
+++ b/backend/src/plugins/Automod/actions/addRoles.ts
@@ -48,7 +48,6 @@ export const AddRolesAction = automodAction({
           "**, **",
         )}**`,
       });
-      return;
     }
 
     await Promise.all(

--- a/backend/src/plugins/Automod/actions/availableActions.ts
+++ b/backend/src/plugins/Automod/actions/availableActions.ts
@@ -6,6 +6,7 @@ import { AlertAction } from "./alert";
 import { ArchiveThreadAction } from "./archiveThread";
 import { BanAction } from "./ban";
 import { ChangeNicknameAction } from "./changeNickname";
+import { ChangeRolesAction } from "./changeRoles";
 import { CleanAction } from "./clean";
 import { KickAction } from "./kick";
 import { LogAction } from "./log";
@@ -34,6 +35,7 @@ export const availableActions: Record<string, AutomodActionBlueprint<any>> = {
   set_counter: SetCounterAction,
   set_slowmode: SetSlowmodeAction,
   archive_thread: ArchiveThreadAction,
+  change_roles: ChangeRolesAction,
 };
 
 export const AvailableActions = t.type({
@@ -53,4 +55,5 @@ export const AvailableActions = t.type({
   set_counter: SetCounterAction.configType,
   set_slowmode: SetSlowmodeAction.configType,
   archive_thread: ArchiveThreadAction.configType,
+  change_roles: ChangeRolesAction.configType,
 });

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -1,5 +1,6 @@
 import { Permissions, Snowflake } from "discord.js";
 import * as t from "io-ts";
+import isEqual from "lodash.isequal";
 import { nonNullish, unique } from "../../../utils";
 import { canAssignRole } from "../../../utils/canAssignRole";
 import { getMissingPermissions } from "../../../utils/getMissingPermissions";
@@ -11,10 +12,15 @@ import { automodAction } from "../helpers";
 
 const p = Permissions.FLAGS;
 
-export const RemoveRolesAction = automodAction({
-  configType: t.array(t.string),
-
-  defaultConfig: [],
+export const ChangeRolesAction = automodAction({
+  configType: t.type({
+    add: t.array(t.string),
+    remove: t.array(t.string),
+  }),
+  defaultConfig: {
+    add: [],
+    remove: [],
+  },
 
   async apply({ pluginData, contexts, actionConfig, ruleName }) {
     const members = unique(contexts.map(c => c.member).filter(nonNullish));
@@ -24,19 +30,40 @@ export const RemoveRolesAction = automodAction({
     if (missingPermissions) {
       const logs = pluginData.getPlugin(LogsPlugin);
       logs.logBotAlert({
-        body: `Cannot remove roles in Automod rule **${ruleName}**. ${missingPermissionError(missingPermissions)}`,
+        body: `Cannot edit roles in Automod rule **${ruleName}**. ${missingPermissionError(missingPermissions)}`,
       });
       return;
     }
 
+    const rolesToAssign: string[] = [];
+    const rolesWeCannotAssign: string[] = [];
     const rolesToRemove: string[] = [];
     const rolesWeCannotRemove: string[] = [];
-    for (const roleId of actionConfig) {
+    for (const roleId of actionConfig.add) {
+      if (canAssignRole(pluginData.guild, me, roleId)) {
+        rolesToAssign.push(roleId);
+      } else {
+        rolesWeCannotAssign.push(roleId);
+      }
+    }
+    for (const roleId of actionConfig.remove) {
       if (canAssignRole(pluginData.guild, me, roleId)) {
         rolesToRemove.push(roleId);
       } else {
         rolesWeCannotRemove.push(roleId);
       }
+    }
+
+    if (rolesWeCannotAssign.length) {
+      const roleNamesWeCannotAssign = rolesWeCannotAssign.map(
+        roleId => pluginData.guild.roles.cache.get(roleId as Snowflake)?.name || roleId,
+      );
+      const logs = pluginData.getPlugin(LogsPlugin);
+      logs.logBotAlert({
+        body: `Unable to assign the following roles in Automod rule **${ruleName}**: **${roleNamesWeCannotAssign.join(
+          "**, **",
+        )}**`,
+      });
     }
 
     if (rolesWeCannotRemove.length) {
@@ -55,12 +82,16 @@ export const RemoveRolesAction = automodAction({
     await Promise.all(
       members.map(async member => {
         const memberRoles = new Set(member.roles.cache.keys());
+        for (const roleId of rolesToAssign) {
+          memberRoles.add(roleId as Snowflake);
+          ignoreRoleChange(pluginData, member.id, roleId);
+        }
         for (const roleId of rolesToRemove) {
           memberRoles.delete(roleId as Snowflake);
           ignoreRoleChange(pluginData, member.id, roleId);
         }
 
-        if (memberRoles.size === member.roles.cache.size) {
+        if (isEqual(memberRoles, member.roles.cache.keys())) {
           // No role changes
           return;
         }

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -10,8 +10,6 @@ import { LogsPlugin } from "../../Logs/LogsPlugin";
 import { ignoreRoleChange } from "../functions/ignoredRoleChanges";
 import { automodAction } from "../helpers";
 
-const p = Permissions.FLAGS;
-
 export const ChangeRolesAction = automodAction({
   configType: t.type({
     add: t.array(t.string),

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -52,28 +52,15 @@ export const ChangeRolesAction = automodAction({
       }
     }
 
-    if (rolesWeCannotAssign.length) {
-      const roleNamesWeCannotAssign = rolesWeCannotAssign.map(
-        roleId => pluginData.guild.roles.cache.get(roleId)?.name || roleId,
-      );
+    if (rolesWeCannotAssign.length || rolesWeCannotRemove.length) {
+      const mapFn = (roleId: Snowflake) => pluginData.guild.roles.cache.get(roleId)?.name || roleId;
+      const roleNamesWeCannotAssign = rolesWeCannotAssign.map(mapFn);
+      const roleNamesWeCannotRemove = rolesWeCannotRemove.map(mapFn);
       const logs = pluginData.getPlugin(LogsPlugin);
-      logs.logBotAlert({
-        body: `Unable to assign the following roles in Automod rule **${ruleName}**: **${roleNamesWeCannotAssign.join(
-          "**, **",
-        )}**`,
-      });
-    }
-
-    if (rolesWeCannotRemove.length) {
-      const roleNamesWeCannotRemove = rolesWeCannotRemove.map(
-        roleId => pluginData.guild.roles.cache.get(roleId)?.name || roleId,
-      );
-      const logs = pluginData.getPlugin(LogsPlugin);
-      logs.logBotAlert({
-        body: `Unable to remove the following roles in Automod rule **${ruleName}**: **${roleNamesWeCannotRemove.join(
-          "**, **",
-        )}**`,
-      });
+      let body = `Unable to change roles in Automod rule **${ruleName}**:`;
+      if (roleNamesWeCannotAssign.length) body += `\n**Add:** ${roleNamesWeCannotAssign.join("**, **")}}`;
+      if (roleNamesWeCannotRemove.length) body += `\n**Remove:** ${roleNamesWeCannotRemove.join("**, **")}}`;
+      logs.logBotAlert({ body });
     }
 
     await Promise.all(

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -22,7 +22,7 @@ export const ChangeRolesAction = automodAction({
 
   async apply({ pluginData, contexts, actionConfig, ruleName }) {
     const members = unique(contexts.map(c => c.member).filter(nonNullish));
-    const me = pluginData.guild.members.cache.get(pluginData.client.user!.id)!;
+    const me = pluginData.guild.me ?? await pluginData.guild.members.fetch(pluginData.client.user!.id);
 
     const missingPermissions = getMissingPermissions(me.permissions, Permissions.FLAGS.MANAGE_ROLES);
     if (missingPermissions) {

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -66,7 +66,7 @@ export const ChangeRolesAction = automodAction({
 
     if (rolesWeCannotRemove.length) {
       const roleNamesWeCannotRemove = rolesWeCannotRemove.map(
-        roleId => pluginData.guild.roles.cache.get(roleId as Snowflake)?.name || roleId,
+        roleId => pluginData.guild.roles.cache.get(roleId)?.name || roleId,
       );
       const logs = pluginData.getPlugin(LogsPlugin);
       logs.logBotAlert({

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -96,9 +96,7 @@ export const ChangeRolesAction = automodAction({
         const memberRoleLock = await pluginData.locks.acquire(memberRolesLock(member));
 
         const rolesArr = Array.from(memberRoles.values());
-        await member.edit({
-          roles: rolesArr,
-        });
+        await member.roles.set(rolesArr);
 
         memberRoleLock.unlock();
       }),

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -22,7 +22,7 @@ export const ChangeRolesAction = automodAction({
 
   async apply({ pluginData, contexts, actionConfig, ruleName }) {
     const members = unique(contexts.map(c => c.member).filter(nonNullish));
-    const me = pluginData.guild.me ?? await pluginData.guild.members.fetch(pluginData.client.user!.id);
+    const me = pluginData.guild.me ?? (await pluginData.guild.members.fetch(pluginData.client.user!.id));
 
     const missingPermissions = getMissingPermissions(me.permissions, Permissions.FLAGS.MANAGE_ROLES);
     if (missingPermissions) {
@@ -88,7 +88,7 @@ export const ChangeRolesAction = automodAction({
           ignoreRoleChange(pluginData, member.id, roleId);
         }
 
-        if (isEqual(memberRoles, member.roles.cache.keys())) {
+        if (isEqual(Array.from(memberRoles), Array.from(member.roles.cache.keys()))) {
           // No role changes
           return;
         }

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -74,7 +74,6 @@ export const ChangeRolesAction = automodAction({
           "**, **",
         )}**`,
       });
-      return;
     }
 
     await Promise.all(

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -24,7 +24,7 @@ export const ChangeRolesAction = automodAction({
     const members = unique(contexts.map(c => c.member).filter(nonNullish));
     const me = pluginData.guild.members.cache.get(pluginData.client.user!.id)!;
 
-    const missingPermissions = getMissingPermissions(me.permissions, p.MANAGE_ROLES);
+    const missingPermissions = getMissingPermissions(me.permissions, Permissions.FLAGS.MANAGE_ROLES);
     if (missingPermissions) {
       const logs = pluginData.getPlugin(LogsPlugin);
       logs.logBotAlert({

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -84,7 +84,7 @@ export const ChangeRolesAction = automodAction({
           ignoreRoleChange(pluginData, member.id, roleId);
         }
         for (const roleId of rolesToRemove) {
-          memberRoles.delete(roleId as Snowflake);
+          memberRoles.delete(roleId);
           ignoreRoleChange(pluginData, member.id, roleId);
         }
 

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -54,7 +54,7 @@ export const ChangeRolesAction = automodAction({
 
     if (rolesWeCannotAssign.length) {
       const roleNamesWeCannotAssign = rolesWeCannotAssign.map(
-        roleId => pluginData.guild.roles.cache.get(roleId as Snowflake)?.name || roleId,
+        roleId => pluginData.guild.roles.cache.get(roleId)?.name || roleId,
       );
       const logs = pluginData.getPlugin(LogsPlugin);
       logs.logBotAlert({

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -80,7 +80,7 @@ export const ChangeRolesAction = automodAction({
       members.map(async member => {
         const memberRoles = new Set(member.roles.cache.keys());
         for (const roleId of rolesToAssign) {
-          memberRoles.add(roleId as Snowflake);
+          memberRoles.add(roleId);
           ignoreRoleChange(pluginData, member.id, roleId);
         }
         for (const roleId of rolesToRemove) {

--- a/backend/src/plugins/Automod/actions/changeRoles.ts
+++ b/backend/src/plugins/Automod/actions/changeRoles.ts
@@ -33,10 +33,10 @@ export const ChangeRolesAction = automodAction({
       return;
     }
 
-    const rolesToAssign: string[] = [];
-    const rolesWeCannotAssign: string[] = [];
-    const rolesToRemove: string[] = [];
-    const rolesWeCannotRemove: string[] = [];
+    const rolesToAssign: Snowflake[] = [];
+    const rolesWeCannotAssign: Snowflake[] = [];
+    const rolesToRemove: Snowflake[] = [];
+    const rolesWeCannotRemove: Snowflake[] = [];
     for (const roleId of actionConfig.add) {
       if (canAssignRole(pluginData.guild, me, roleId)) {
         rolesToAssign.push(roleId);

--- a/backend/src/plugins/Automod/actions/removeRoles.ts
+++ b/backend/src/plugins/Automod/actions/removeRoles.ts
@@ -49,7 +49,6 @@ export const RemoveRolesAction = automodAction({
           "**, **",
         )}**`,
       });
-      return;
     }
 
     await Promise.all(


### PR DESCRIPTION
```yaml
plugins:
  automod:
    config:
      rules:
        testrule:
          triggers:
            - match_words:
                words: ["testrl"]
          actions:
            change_roles:
              add: ["885116460261863425"]
              remove: ["885116523067375666"]
```

### Fixes
This PR is meant to fix the issue of having both `add_roles` and `remove_roles` not functioning when used together.
I tried to fix the core issue at hand with the individual methods (i.e. the Member object's roles not being up-to-date by the time it reaches the 2nd action) but there was no super easy fix for this that I could find.

Regardless it would've still been 2 dapi requests, with this PR all role changes originating from a rule are now guaranteed to only be a single dapi request (since you can no longer use both `add_roles` and `remove_roles`)

@almeidx wtb review