### PR TITLE
Added automod unarchive_thread action

### DIFF
--- a/backend/src/plugins/Automod/actions/archiveThread.ts
+++ b/backend/src/plugins/Automod/actions/archiveThread.ts
@@ -15,12 +15,13 @@ export const ArchiveThreadAction = automodAction({
     const threads = contexts
       .filter((c) => c.message?.channel_id)
       .map((c) => pluginData.guild.channels.cache.get(c.message!.channel_id))
-      .filter((c): c is ThreadChannel => (c?.isThread() && !c.archived) ?? false);
+      .filter((c): c is ThreadChannel => c?.isThread() ?? false);
 
     for (const thread of threads) {
-      if (actionConfig.lock) {
+      if (actionConfig.lock && !thread.locked) {
         await thread.setLocked().catch(noop);
       }
+      if (thread.archived) continue;
       await thread.setArchived().catch(noop);
     }
   },

--- a/backend/src/plugins/Automod/actions/archiveThread.ts
+++ b/backend/src/plugins/Automod/actions/archiveThread.ts
@@ -1,19 +1,26 @@
 import { ThreadChannel } from "discord.js";
 import * as t from "io-ts";
-import { noop } from "../../../utils";
+import { noop, tNullable } from "../../../utils";
 import { automodAction } from "../helpers";
 
 export const ArchiveThreadAction = automodAction({
-  configType: t.type({}),
-  defaultConfig: {},
+  configType: t.type({
+    lock: tNullable(t.boolean),
+  }),
+  defaultConfig: {
+    lock: false,
+  },
 
-  async apply({ pluginData, contexts }) {
+  async apply({ pluginData, contexts, actionConfig }) {
     const threads = contexts
       .filter((c) => c.message?.channel_id)
       .map((c) => pluginData.guild.channels.cache.get(c.message!.channel_id))
-      .filter((c): c is ThreadChannel => c?.isThread() ?? false);
+      .filter((c): c is ThreadChannel => (c?.isThread() && !c.archived) ?? false);
 
     for (const thread of threads) {
+      if (actionConfig.lock) {
+        await thread.setLocked().catch(noop);
+      }
       await thread.setArchived().catch(noop);
     }
   },

--- a/backend/src/plugins/Automod/actions/archiveThread.ts
+++ b/backend/src/plugins/Automod/actions/archiveThread.ts
@@ -13,8 +13,8 @@ export const ArchiveThreadAction = automodAction({
 
   async apply({ pluginData, contexts, actionConfig }) {
     const threads = contexts
-      .filter((c) => c.message?.channel_id)
-      .map((c) => pluginData.guild.channels.cache.get(c.message!.channel_id))
+      .filter((c) => c.thread?.id)
+      .map((c) => pluginData.guild.channels.cache.get(c.thread!.id))
       .filter((c): c is ThreadChannel => c?.isThread() ?? false);
 
     for (const thread of threads) {

--- a/backend/src/plugins/Automod/actions/availableActions.ts
+++ b/backend/src/plugins/Automod/actions/availableActions.ts
@@ -15,6 +15,7 @@ import { ReplyAction } from "./reply";
 import { SetAntiraidLevelAction } from "./setAntiraidLevel";
 import { SetCounterAction } from "./setCounter";
 import { SetSlowmodeAction } from "./setSlowmode";
+import { UnArchiveThreadAction } from "./unArchiveThread";
 import { WarnAction } from "./warn";
 
 export const availableActions: Record<string, AutomodActionBlueprint<any>> = {
@@ -34,6 +35,7 @@ export const availableActions: Record<string, AutomodActionBlueprint<any>> = {
   set_counter: SetCounterAction,
   set_slowmode: SetSlowmodeAction,
   archive_thread: ArchiveThreadAction,
+  unarchive_thread: UnArchiveThreadAction,
 };
 
 export const AvailableActions = t.type({
@@ -53,4 +55,5 @@ export const AvailableActions = t.type({
   set_counter: SetCounterAction.configType,
   set_slowmode: SetSlowmodeAction.configType,
   archive_thread: ArchiveThreadAction.configType,
+  unarchive_thread: UnArchiveThreadAction.configType,
 });

--- a/backend/src/plugins/Automod/actions/unArchiveThread.ts
+++ b/backend/src/plugins/Automod/actions/unArchiveThread.ts
@@ -1,0 +1,27 @@
+import { ThreadChannel } from "discord.js";
+import * as t from "io-ts";
+import { noop, tNullable } from "../../../utils";
+import { automodAction } from "../helpers";
+
+export const UnArchiveThreadAction = automodAction({
+  configType: t.type({
+    unlock: tNullable(t.boolean),
+  }),
+  defaultConfig: {
+    unlock: false,
+  },
+
+  async apply({ pluginData, contexts, actionConfig }) {
+    const threads = contexts
+      .filter((c) => c.message?.channel_id)
+      .map((c) => pluginData.guild.channels.cache.get(c.message!.channel_id))
+      .filter((c): c is ThreadChannel => (c?.isThread() && c.archived) ?? false);
+
+    for (const thread of threads) {
+      if (actionConfig.unlock) {
+        await thread.setLocked(false).catch(noop);
+      }
+      await thread.setArchived(false).catch(noop);
+    }
+  },
+});

--- a/backend/src/plugins/Automod/actions/unArchiveThread.ts
+++ b/backend/src/plugins/Automod/actions/unArchiveThread.ts
@@ -13,8 +13,8 @@ export const UnArchiveThreadAction = automodAction({
 
   async apply({ pluginData, contexts, actionConfig }) {
     const threads = contexts
-      .filter((c) => c.message?.channel_id)
-      .map((c) => pluginData.guild.channels.cache.get(c.message!.channel_id))
+      .filter((c) => c.thread?.id)
+      .map((c) => pluginData.guild.channels.cache.get(c.thread!.id))
       .filter((c): c is ThreadChannel => c?.isThread() ?? false);
 
     for (const thread of threads) {

--- a/backend/src/plugins/Automod/actions/unArchiveThread.ts
+++ b/backend/src/plugins/Automod/actions/unArchiveThread.ts
@@ -15,12 +15,13 @@ export const UnArchiveThreadAction = automodAction({
     const threads = contexts
       .filter((c) => c.message?.channel_id)
       .map((c) => pluginData.guild.channels.cache.get(c.message!.channel_id))
-      .filter((c): c is ThreadChannel => (c?.isThread() && c.archived) ?? false);
+      .filter((c): c is ThreadChannel => c?.isThread() ?? false);
 
     for (const thread of threads) {
-      if (actionConfig.unlock) {
+      if (actionConfig.unlock && thread.locked) {
         await thread.setLocked(false).catch(noop);
       }
+      if (!thread.archived) continue;
       await thread.setArchived(false).catch(noop);
     }
   },


### PR DESCRIPTION
# Depends on #292
Adds `lock` property to `archive_thread` action to optionally moderator-archive a thread.

The `unlock` property on the `unarchive_thread` action is something I'm not sure is gonna be used too much in practice, though it does serve a different functional purpose to just forcefully unlocking/unarchiving threads.
But change it to your liking /shrug

![image](https://user-images.githubusercontent.com/9076708/133287724-035e83b0-4dbb-41f4-9daa-98b92f48aa06.png)
