### PR TITLE
Add check to refreshApiKeyExpiryTime to not refresh long lived keys

### DIFF
--- a/backend/src/data/ApiLogins.ts
+++ b/backend/src/data/ApiLogins.ts
@@ -94,10 +94,7 @@ export class ApiLogins extends BaseRepository {
 
     const login = await this.apiLogins.createQueryBuilder().where("id = :id", { id: loginId }).getOne();
 
-    if (!login) return;
-
-    if (moment.utc(login.expires_at).isSameOrAfter(updatedTime)) return;
-
+    if (!login || moment.utc(login.expires_at).isSameOrAfter(updatedTime)) return;
     await this.apiLogins.update(
       { id: loginId },
       {

--- a/backend/src/data/ApiLogins.ts
+++ b/backend/src/data/ApiLogins.ts
@@ -93,8 +93,8 @@ export class ApiLogins extends BaseRepository {
     const updatedTime = moment().utc().add(LOGIN_EXPIRY_TIME, "ms");
 
     const login = await this.apiLogins.createQueryBuilder().where("id = :id", { id: loginId }).getOne();
-
     if (!login || moment.utc(login.expires_at).isSameOrAfter(updatedTime)) return;
+    
     await this.apiLogins.update(
       { id: loginId },
       {

--- a/backend/src/data/ApiLogins.ts
+++ b/backend/src/data/ApiLogins.ts
@@ -90,10 +90,21 @@ export class ApiLogins extends BaseRepository {
     const [loginId, token] = apiKey.split(".");
     if (!loginId || !token) return;
 
+    const updated_time =  moment().utc().add(LOGIN_EXPIRY_TIME, "ms");
+
+    const login = await this.apiLogins
+      .createQueryBuilder()
+      .where("id = :id", { id: loginId })
+      .getOne();
+    
+     if(!login) return;
+
+    if(moment.utc(login.expires_at).isSameOrAfter(updated_time)) return;
+
     await this.apiLogins.update(
       { id: loginId },
       {
-        expires_at: moment().utc().add(LOGIN_EXPIRY_TIME, "ms").format(DBDateFormat),
+        expires_at: updated_time.format(DBDateFormat)
       },
     );
   }

--- a/backend/src/data/ApiLogins.ts
+++ b/backend/src/data/ApiLogins.ts
@@ -90,21 +90,18 @@ export class ApiLogins extends BaseRepository {
     const [loginId, token] = apiKey.split(".");
     if (!loginId || !token) return;
 
-    const updated_time =  moment().utc().add(LOGIN_EXPIRY_TIME, "ms");
+    const updatedTime = moment().utc().add(LOGIN_EXPIRY_TIME, "ms");
 
-    const login = await this.apiLogins
-      .createQueryBuilder()
-      .where("id = :id", { id: loginId })
-      .getOne();
-    
-     if(!login) return;
+    const login = await this.apiLogins.createQueryBuilder().where("id = :id", { id: loginId }).getOne();
 
-    if(moment.utc(login.expires_at).isSameOrAfter(updated_time)) return;
+    if (!login) return;
+
+    if (moment.utc(login.expires_at).isSameOrAfter(updatedTime)) return;
 
     await this.apiLogins.update(
       { id: loginId },
       {
-        expires_at: updated_time.format(DBDateFormat)
+        expires_at: updatedTime.format(DBDateFormat),
       },
     );
   }


### PR DESCRIPTION
This PR is to allow long lived ApiKeys to be used in an automated deployment. This is mostly for self-hosted instances, but if a long lived ApiKey is created in the main host by Dragory, this allows it to be used for more than a day. Tested on the Splitgate Server host