### PR TITLE
Automod add changeperms action

### DIFF
--- a/backend/src/plugins/Automod/actions/availableActions.ts
+++ b/backend/src/plugins/Automod/actions/availableActions.ts
@@ -6,6 +6,7 @@ import { AlertAction } from "./alert";
 import { ArchiveThreadAction } from "./archiveThread";
 import { BanAction } from "./ban";
 import { ChangeNicknameAction } from "./changeNickname";
+import { ChangePermsAction } from "./changePerms";
 import { CleanAction } from "./clean";
 import { KickAction } from "./kick";
 import { LogAction } from "./log";
@@ -36,6 +37,7 @@ export const availableActions: Record<string, AutomodActionBlueprint<any>> = {
   set_slowmode: SetSlowmodeAction,
   start_thread: StartThreadAction,
   archive_thread: ArchiveThreadAction,
+  change_perms: ChangePermsAction,
 };
 
 export const AvailableActions = t.type({
@@ -56,4 +58,5 @@ export const AvailableActions = t.type({
   set_slowmode: SetSlowmodeAction.configType,
   start_thread: StartThreadAction.configType,
   archive_thread: ArchiveThreadAction.configType,
+  change_perms: ChangePermsAction.configType,
 });

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -28,7 +28,7 @@ export const ChangePermsAction = automodAction({
         new TemplateSafeValueContainer({
           user: user ? userToTemplateSafeUser(user) : null,
           guild: guildToTemplateSafeGuild(pluginData.guild),
-          msg: message ? savedMessageToTemplateSafeSavedMessage(message) : null,
+          message: message ? savedMessageToTemplateSafeSavedMessage(message) : null,
         }),
       );
     const renderChannel = async (str: string) =>
@@ -37,7 +37,7 @@ export const ChangePermsAction = automodAction({
         new TemplateSafeValueContainer({
           user: user ? userToTemplateSafeUser(user) : null,
           guild: guildToTemplateSafeGuild(pluginData.guild),
-          msg: message ? savedMessageToTemplateSafeSavedMessage(message) : null,
+          message: message ? savedMessageToTemplateSafeSavedMessage(message) : null,
         }),
       );
     const target = await renderTarget(actionConfig.target);

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -80,7 +80,7 @@ export const ChangePermsAction = automodAction({
         await channel.permissionOverwrites.delete(target).catch(noop);
         return;
       }
-      await channel.permissionOverwrites.create(target, newPerms).catch(noop);
+      await channel.permissionOverwrites.edit(target, newPerms).catch(noop);
       return;
     }
 

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -31,6 +31,7 @@ export const ChangePermsAction = automodAction({
       const allow = new Permissions(overwrite ? overwrite.allow : "0").serialize();
       const deny = new Permissions(overwrite ? overwrite.deny : "0").serialize();
       const newPerms: Partial<Record<PermissionString, boolean | null>> = {};
+      let hasPerms = false;
 
       for (const key in allow) {
         if (typeof actionConfig.perms[key] !== "undefined") {
@@ -39,9 +40,15 @@ export const ChangePermsAction = automodAction({
         }
         if (allow[key]) {
           newPerms[key] = true;
+          hasPerms = true;
         } else if (deny[key]) {
           newPerms[key] = false;
+          hasPerms = true;
         }
+      }
+      if (overwrite && !hasPerms) {
+        await channel.permissionOverwrites.delete(actionConfig.target).catch(noop);
+        return;
       }
       await channel.permissionOverwrites.create(actionConfig.target, newPerms).catch(noop);
       return;

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -49,7 +49,7 @@ export const ChangePermsAction = automodAction({
       const channel = await pluginData.guild.channels.fetch(channelId);
       if (!channel) return;
       const overwrite = channel.permissionOverwrites.cache.find((pw) => pw.id === target);
-      const allow = new Permissions(overwrite ? overwrite.allow : "0").serialize();
+      const allow = new Permissions(overwrite?.allow ?? 0n).serialize();
       const deny = new Permissions(overwrite ? overwrite.deny : "0").serialize();
       const newPerms: Partial<Record<PermissionString, boolean | null>> = {};
 

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -39,14 +39,14 @@ export const ChangePermsAction = automodAction({
       );
     const target = await renderTarget(actionConfig.target);
     const channelId = actionConfig.channel ? await renderChannel(actionConfig.channel) : null;
-    const role = await pluginData.guild.roles.fetch(target);
+    const role = pluginData.guild.roles.resolve(target);
     if (!role) {
       const member = await pluginData.guild.members.fetch(target).catch(noop);
       if (!member) return;
     }
 
     if (channelId && isValidSnowflake(channelId)) {
-      const channel = await pluginData.guild.channels.fetch(channelId);
+      const channel = pluginData.guild.channels.resolve(channelId);
       if (!channel) return;
       const overwrite = channel.permissionOverwrites.cache.find((pw) => pw.id === target);
       const allow = new Permissions(overwrite?.allow ?? 0n).serialize();

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -47,7 +47,7 @@ export const ChangePermsAction = automodAction({
 
     if (channelId && isValidSnowflake(channelId)) {
       const channel = pluginData.guild.channels.resolve(channelId);
-      if (!channel) return;
+      if (!channel || channel.isThread()) return;
       const overwrite = channel.permissionOverwrites.cache.find((pw) => pw.id === target);
       const allow = new Permissions(overwrite?.allow ?? 0n).serialize();
       const deny = new Permissions(overwrite?.deny ?? 0n).serialize();

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -41,7 +41,7 @@ export const ChangePermsAction = automodAction({
     const channelId = actionConfig.channel ? await renderChannel(actionConfig.channel) : null;
     const role = await pluginData.guild.roles.fetch(target);
     if (!role) {
-      const member = await pluginData.guild.members.fetch(target);
+      const member = await pluginData.guild.members.fetch(target).catch(noop);
       if (!member) return;
     }
 

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -1,17 +1,20 @@
 import { Permissions, PermissionString } from "discord.js";
 import * as t from "io-ts";
 import { automodAction } from "../helpers";
-import { tNullable, isValidSnowflake } from "../../../utils";
+import { tNullable, isValidSnowflake, tPartialDictionary } from "../../../utils";
 import { noop } from "knub/dist/utils";
 
 export const ChangePermsAction = automodAction({
   configType: t.type({
     target: t.string,
     channel: tNullable(t.string),
-    perms: t.record(t.keyof(Permissions.FLAGS), t.union([t.boolean, t.null])),
+    perms: tPartialDictionary(t.keyof(Permissions.FLAGS), tNullable(t.boolean)),
   }),
   defaultConfig: {
     channel: "",
+    perms: {
+      SEND_MESSAGES: true,
+    },
   },
 
   async apply({ pluginData, contexts, actionConfig, ruleName }) {
@@ -50,7 +53,7 @@ export const ChangePermsAction = automodAction({
     for (const key in actionConfig.perms) {
       perms[key] = actionConfig.perms[key];
     }
-    const permsArray: PermissionString[] = <any>Object.keys(perms).filter((key) => perms[key]);
+    const permsArray = <PermissionString[]>Object.keys(perms).filter((key) => perms[key]);
     await role.setPermissions(new Permissions(permsArray)).catch(noop);
   },
 });

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -16,12 +16,7 @@ export const ChangePermsAction = automodAction({
     channel: tNullable(t.string),
     perms: tPartialDictionary(t.keyof(Permissions.FLAGS), tNullable(t.boolean)),
   }),
-  defaultConfig: {
-    channel: "",
-    perms: {
-      SEND_MESSAGES: true,
-    },
-  },
+  defaultConfig: {},
 
   async apply({ pluginData, contexts, actionConfig, ruleName }) {
     const user = contexts.find((c) => c.user)?.user;

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -28,12 +28,15 @@ export const ChangePermsAction = automodAction({
         new TemplateSafeValueContainer({
           user: user ? userToTemplateSafeUser(user) : null,
           guild: guildToTemplateSafeGuild(pluginData.guild),
+          msg: message ? savedMessageToTemplateSafeSavedMessage(message) : null,
         }),
       );
     const renderChannel = async (str: string) =>
       renderTemplate(
         str,
         new TemplateSafeValueContainer({
+          user: user ? userToTemplateSafeUser(user) : null,
+          guild: guildToTemplateSafeGuild(pluginData.guild),
           msg: message ? savedMessageToTemplateSafeSavedMessage(message) : null,
         }),
       );

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -1,0 +1,56 @@
+import { Permissions, PermissionString } from "discord.js";
+import * as t from "io-ts";
+import { automodAction } from "../helpers";
+import { tNullable, isValidSnowflake } from "../../../utils";
+import { noop } from "knub/dist/utils";
+
+export const ChangePermsAction = automodAction({
+  configType: t.type({
+    target: t.string,
+    channel: tNullable(t.string),
+    perms: t.record(t.keyof(Permissions.FLAGS), t.union([t.boolean, t.null])),
+  }),
+  defaultConfig: {
+    channel: "",
+  },
+
+  async apply({ pluginData, contexts, actionConfig, ruleName }) {
+    const role = await pluginData.guild.roles.fetch(actionConfig.target);
+    if (!role) {
+      const member = await pluginData.guild.members.fetch(actionConfig.target);
+      if (!member) return;
+    }
+
+    if (actionConfig.channel && isValidSnowflake(actionConfig.channel)) {
+      const channel = await pluginData.guild.channels.fetch(actionConfig.channel);
+      if (!channel) return;
+      const overwrite = channel.permissionOverwrites.cache.find((pw) => pw.id === actionConfig.target);
+      const allow = new Permissions(overwrite ? overwrite.allow : "0").serialize();
+      const deny = new Permissions(overwrite ? overwrite.deny : "0").serialize();
+      const newPerms: Partial<Record<PermissionString, boolean | null>> = {};
+
+      for (const key in allow) {
+        if (typeof actionConfig.perms[key] !== "undefined") {
+          newPerms[key] = actionConfig.perms[key];
+          continue;
+        }
+        if (allow[key]) {
+          newPerms[key] = true;
+        } else if (deny[key]) {
+          newPerms[key] = false;
+        }
+      }
+      await channel.permissionOverwrites.create(actionConfig.target, newPerms).catch(noop);
+      return;
+    }
+
+    if (!role) return;
+
+    const perms = new Permissions(role.permissions).serialize();
+    for (const key in actionConfig.perms) {
+      perms[key] = actionConfig.perms[key];
+    }
+    const permsArray: PermissionString[] = <any>Object.keys(perms).filter((key) => perms[key]);
+    await role.setPermissions(new Permissions(permsArray)).catch(noop);
+  },
+});

--- a/backend/src/plugins/Automod/actions/changePerms.ts
+++ b/backend/src/plugins/Automod/actions/changePerms.ts
@@ -50,7 +50,7 @@ export const ChangePermsAction = automodAction({
       if (!channel) return;
       const overwrite = channel.permissionOverwrites.cache.find((pw) => pw.id === target);
       const allow = new Permissions(overwrite?.allow ?? 0n).serialize();
-      const deny = new Permissions(overwrite ? overwrite.deny : "0").serialize();
+      const deny = new Permissions(overwrite?.deny ?? 0n).serialize();
       const newPerms: Partial<Record<PermissionString, boolean | null>> = {};
 
       for (const key in allow) {


### PR DESCRIPTION
adds server/role/member perm changing action.

does not REPLACE existing permissions for each object (roles/perm overwrites), but instead changes only the ones specified.

if `channel` is not provided, will default to serverwide perms, if a member's ID is provided in `target`, will silently fail if `channel` is not a valid channel.

There's probably some concern here or there for checking that the permissions we're changing doesn't end up being the same as what's already defined on discord's side, to save a few api calls, but I don't think this is a major issue, and I couldn't think of a super simple, clean and easy way to check this with this code.
@almeidx will probably roast me for it so I thought I'd mention it ahead of time just to mention that I did think of this problem.

samples:

```yaml
plugins:
  automod:
    config:
      rules:
        lockdown:
          triggers:
            - match_regex:
                patterns:
                  - 'lockdown'
          actions:
            reply: "Done lockdown"
            log: true
            change_perms:
              target: "{guild.id}" # the @everyone role
              perms:
                SEND_MESSAGES: false
        mute:
          triggers:
            - match_regex:
                patterns:
                  - 'mute'
          actions:
            reply: "Done mute"
            log: true
            change_perms:
              target: "{user.id}"
              channel: "{msg.channel_id}"
              perms:
                SEND_MESSAGES: false # adds a channel override
        unmute:
          triggers:
            - match_regex:
                patterns:
                  - 'unm'
          actions:
            reply: "Done unmute"
            log: true
            change_perms:
              target: "{user.id}"
              channel: "{msg.channel_id}"
              perms:
                SEND_MESSAGES: null # resets channel override
```