### PR TITLE
Update Phisherman endpoint

### DIFF
--- a/backend/src/data/Phisherman.ts
+++ b/backend/src/data/Phisherman.ts
@@ -128,7 +128,7 @@ type DomainInfoApiCallResult = PhishermanUnknownDomain | PhishermanDomainInfo;
 async function fetchDomainInfo(domain: string): Promise<PhishermanDomainInfo | null> {
   // tslint:disable-next-line:no-console
   console.log(`[PHISHERMAN] Requesting domain information: ${domain}`);
-  const result = await apiCall<Record<string, DomainInfoApiCallResult>>("GET", `/v2/domains/info/${domain}`);
+  const result = await apiCall<Record<string, DomainInfoApiCallResult>>("GET", `/v2/domains/check/${domain}`);
   const firstKey = Object.keys(result)[0];
   const domainInfo = firstKey ? result[firstKey] : null;
   if (!domainInfo) {

--- a/backend/src/data/types/phisherman.ts
+++ b/backend/src/data/types/phisherman.ts
@@ -3,30 +3,6 @@ export interface PhishermanUnknownDomain {
 }
 
 export interface PhishermanDomainInfo {
-  status: string;
-  lastChecked: string;
   verifiedPhish: boolean;
   classification: "safe" | "malicious";
-  created: string;
-  firstSeen: string | null;
-  lastSeen: string | null;
-  targetedBrand: string;
-  phishCaught: number;
-  details: PhishermanDomainInfoDetails;
-}
-
-export interface PhishermanDomainInfoDetails {
-  phishTankId: string | null;
-  urlScanId: string;
-  websiteScreenshot: string;
-  ip_address: string;
-  asn: PhishermanDomainInfoAsn;
-  registry: string;
-  country: string;
-}
-
-export interface PhishermanDomainInfoAsn {
-  asn: string;
-  asn_name: string;
-  route: string;
 }


### PR DESCRIPTION
Switch to using `/v2/domains/check/` instead of `/v2/domains/info` for better performance and reliability.

`/check` endpoint now returns required info by Zeppelin:

```
{
    "classification": "suspicious",
    "verifiedPhish": false
}
```