### PR TITLE
fix(tags): embed validation

### DIFF
--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -327,7 +327,7 @@ export const zEmbedInput = z.object({
   title: z.string().optional(),
   description: z.string().optional(),
   url: z.string().optional(),
-  timestamp: z.number().optional(),
+  timestamp: z.string().optional(),
   color: z.number().optional(),
 
   footer: z.optional(


### PR DESCRIPTION
There was a mismatch of types on zod and io-ts
https://github.com/ZeppelinBot/Zeppelin/blob/feeb0488556f10f6b02311476b32797dba314fa5/backend/src/utils.ts#L330
https://github.com/ZeppelinBot/Zeppelin/blob/feeb0488556f10f6b02311476b32797dba314fa5/backend/src/utils.ts#L269

This makes it fail to send tags with embeds that have `timestamp` configured on them since the embed is actually being validated with both

https://github.com/ZeppelinBot/Zeppelin/blob/feeb0488556f10f6b02311476b32797dba314fa5/backend/src/plugins/Tags/util/renderTagFromString.ts#L35
https://github.com/ZeppelinBot/Zeppelin/blob/feeb0488556f10f6b02311476b32797dba314fa5/backend/src/plugins/Tags/util/onMessageCreate.ts#L89
