### PR TITLE
fix: allow 0 deleteMessageDays and fix upper limit

### DIFF
--- a/backend/src/plugins/Automod/actions/ban.ts
+++ b/backend/src/plugins/Automod/actions/ban.ts
@@ -25,7 +25,7 @@ export const BanAction = automodAction({
     const reason = actionConfig.reason || "Kicked automatically";
     const duration = actionConfig.duration ? convertDelayStringToMS(actionConfig.duration)! : undefined;
     const contactMethods = actionConfig.notify ? resolveActionContactMethods(pluginData, actionConfig) : undefined;
-    const deleteMessageDays = actionConfig.deleteMessageDays || undefined;
+    const deleteMessageDays = actionConfig.deleteMessageDays ?? undefined;
 
     const caseArgs: Partial<CaseArgs> = {
       modId: pluginData.client.user!.id,

--- a/backend/src/plugins/ModActions/functions/banUserId.ts
+++ b/backend/src/plugins/ModActions/functions/banUserId.ts
@@ -85,7 +85,7 @@ export async function banUserId(
   pluginData.state.serverLogs.ignoreLog(LogType.MEMBER_BAN, userId);
   ignoreEvent(pluginData, IgnoredEventType.Ban, userId);
   try {
-    const deleteMessageDays = Math.min(30, Math.max(0, banOptions.deleteMessageDays ?? 1));
+    const deleteMessageDays = Math.min(7, Math.max(0, banOptions.deleteMessageDays ?? 1));
     await pluginData.guild.bans.create(userId as Snowflake, {
       days: deleteMessageDays,
       reason: reason ?? undefined,


### PR DESCRIPTION
- `actionConfig.deleteMessageDays || undefined` would incorrectly default `0` to `undefined`
- the range for delete_message_days is 0-7, not 0-30