### PR TITLE
chore: remove double parenthesis in match_attachment_type trigger

### DIFF
--- a/backend/src/plugins/Automod/triggers/matchAttachmentType.ts
+++ b/backend/src/plugins/Automod/triggers/matchAttachmentType.ts
@@ -72,7 +72,7 @@ export const MatchAttachmentTypeTrigger = automodTrigger<MatchResultType>()({
     return (
       asSingleLine(`
         Matched attachment type \`${Util.escapeInlineCode(matchResult.extra.matchedType)}\`
-        (${matchResult.extra.mode === "blacklist" ? "(blacklisted)" : "(not in whitelist)"})
+        (${matchResult.extra.mode === "blacklist" ? "blacklisted" : "not in whitelist"})
         in message (\`${contexts[0].message!.id}\`) in ${prettyChannel}:
       `) + messageSummary(contexts[0].message!)
     );


### PR DESCRIPTION
no reason