### PR TITLE
Fix "Server voice muted" being true even if self-muted, misleading mods into thinking the user was right-click muted by a moderator

### DIFF
--- a/backend/src/plugins/Utility/functions/getUserInfoEmbed.ts
+++ b/backend/src/plugins/Utility/functions/getUserInfoEmbed.ts
@@ -10,6 +10,7 @@ import {
   resolveMember,
   resolveUser,
   sorter,
+  trimEmptyLines,
   trimLines,
   UnknownUser,
 } from "../../../utils";
@@ -124,10 +125,12 @@ export async function getUserInfoEmbed(
     if (voiceChannel || member.voice.mute || member.voice.deaf) {
       embed.fields.push({
         name: preEmbedPadding + "Voice information",
-        value: trimLines(`
+        value: trimEmptyLines(`
           ${voiceChannel ? `Current voice channel: **${voiceChannel.name ?? "None"}**` : ""}
-          ${member.voice.mute ? "Server voice muted: **Yes**" : ""}
-          ${member.voice.deaf ? "Server voice deafened: **Yes**" : ""}
+          ${member.voice.serverMute ? "Server-muted: **Yes**" : ""}
+          ${member.voice.serverDeaf ? "Server-deafened: **Yes**" : ""}
+          ${member.voice.selfMute ? "Self-muted: **Yes**" : ""}
+          ${member.voice.selfDeaf ? "Self-deafened: **Yes**" : ""}
         `),
       });
     }


### PR DESCRIPTION
Instead split the options into all four, from mute and deaf to selfMute, selfDeaf, serverMute and serverDeaf.
This should provide a lot more clarity.