### PR TITLE
feat: Tag list search and improved readability

### DIFF
--- a/backend/src/plugins/Tags/commands/TagListCmd.ts
+++ b/backend/src/plugins/Tags/commands/TagListCmd.ts
@@ -1,3 +1,4 @@
+import { commandTypeHelpers as ct } from "../../../commandTypes";
 import { createChunkedMessage } from "../../../utils";
 import { tagsCmd } from "../types";
 
@@ -5,7 +6,11 @@ export const TagListCmd = tagsCmd({
   trigger: ["tag list", "tags", "taglist"],
   permission: "can_list",
 
-  async run({ message: msg, pluginData }) {
+  signature: {
+    search: ct.string({ required: false }),
+  },
+
+  async run({ message: msg, args, pluginData }) {
     const tags = await pluginData.state.tags.all();
     if (tags.length === 0) {
       msg.channel.send(`No tags created yet! Use \`tag create\` command to create one.`);
@@ -15,6 +20,33 @@ export const TagListCmd = tagsCmd({
     const prefix = (await pluginData.config.getForMessage(msg)).prefix;
     const tagNames = tags.map((tag) => tag.tag).sort();
 
-    createChunkedMessage(msg.channel, `Available tags (use with ${prefix}tag): \`\`\`${tagNames.join(", ")}\`\`\``);
+    const filteredTags = args.search
+      ? tagNames.filter((tag) =>
+          new RegExp(
+            args.search
+              .split("")
+              .map((char) => char.replace(/[.*+?^${}()|[\]\\]/, "\\$&"))
+              .join(".*")
+          ).test(tag)
+        )
+      : tagNames;
+
+    const tagGroups = filteredTags.reduce((acc, tag) => {
+      const obj = { ...acc };
+      const tagUpper = tag.toUpperCase();
+      const key = /[A-Z]/.test(tagUpper[0]) ? tagUpper[0] : "#";
+      if (!(key in obj)) {
+        obj[key] = [];
+      }
+      obj[key].push(tag);
+      return obj;
+    }, {});
+
+    const tagList = Object.keys(tagGroups)
+      .sort()
+      .map((key) => `[${key}] ${tagGroups[key].join(", ")}`)
+      .join("\n");
+
+    createChunkedMessage(msg.channel, `Available tags (use with ${prefix}tag): \`\`\`${tagList}\`\`\``);
   },
 });


### PR DESCRIPTION
Resolves #347 

Improves the readability of the tag list by grouping tags by their first letter for easy scanning.

Additionally, adds the feature to filter tags based on the letters contained within the tag name, for example, the search "ts" would show results for tags named "ts", "test", "typescript", etc. as the letters appear in the tag name in the given order.

Note: this has only been tested on mock data, not an actual running instance.

Example:

![image](https://user-images.githubusercontent.com/20955511/174940411-539d0131-8bb4-4633-a726-df3a5721b573.png)

![image](https://user-images.githubusercontent.com/20955511/174940518-916cd609-7c67-49a7-9582-ea88d2531567.png)