### PR TITLE
Update Repo URL on Privacy Policy

### DIFF
--- a/dashboard/src/components/PrivacyPolicy.vue
+++ b/dashboard/src/components/PrivacyPolicy.vue
@@ -16,8 +16,8 @@
       </p>
       <p>
         The bot's source code is available at
-        <a href="https://github.com/Dragory/ZeppelinBot">
-          https://github.com/Dragory/ZeppelinBot
+        <a href="https://github.com/ZeppelinBot/Zeppelin">
+          https://github.com/ZeppelinBot/Zeppelin
         </a>
       </p>
 


### PR DESCRIPTION
I'm aware that both links redirect to the same place, but this fix would allow Dragory to make a new repo called ZeppelinBot in the future (despite the unlikelyhood) whilst maintaining the functionality of the Privacy Policy.