### PR TITLE
feat: Make tag list search case-insensitive

### DIFF
--- a/backend/src/plugins/Tags/commands/TagListCmd.ts
+++ b/backend/src/plugins/Tags/commands/TagListCmd.ts
@@ -20,7 +20,7 @@ export const TagListCmd = tagsCmd({
 
     const prefix = (await pluginData.config.getForMessage(msg)).prefix;
     const tagNames = tags.map((tag) => tag.tag).sort();
-    const searchRegex = args.search ? new RegExp([...args.search].map((s) => escapeStringRegexp(s)).join(".*")) : null;
+    const searchRegex = args.search ? new RegExp([...args.search].map((s) => escapeStringRegexp(s)).join(".*"), "i") : null;
 
     const filteredTags = args.search ? tagNames.filter((tag) => searchRegex!.test(tag)) : tagNames;
 


### PR DESCRIPTION
This is a very minor change that will make search terms case-insensitive when using `!tags [search]` or `!tag list [search]`

For example, `!tag Example` would list tags that include the word `"example"` even though the search term has an uppercase E.