### PR TITLE
Add option to trigger antiraid_level only on change

### DIFF
--- a/backend/src/plugins/Automod/events/runAutomodOnAntiraidLevel.ts
+++ b/backend/src/plugins/Automod/events/runAutomodOnAntiraidLevel.ts
@@ -5,13 +5,15 @@ import { AutomodContext, AutomodPluginType } from "../types";
 
 export async function runAutomodOnAntiraidLevel(
   pluginData: GuildPluginData<AutomodPluginType>,
-  level: string | null,
+  newLevel: string | null,
+  oldLevel: string | null,
   user?: User,
 ) {
   const context: AutomodContext = {
     timestamp: Date.now(),
     antiraid: {
-      level,
+      level: newLevel,
+      oldLevel,
     },
     user,
   };

--- a/backend/src/plugins/Automod/functions/setAntiraidLevel.ts
+++ b/backend/src/plugins/Automod/functions/setAntiraidLevel.ts
@@ -9,10 +9,11 @@ export async function setAntiraidLevel(
   newLevel: string | null,
   user?: User,
 ) {
+  const oldLevel = pluginData.state.cachedAntiraidLevel;
   pluginData.state.cachedAntiraidLevel = newLevel;
   await pluginData.state.antiraidLevels.set(newLevel);
 
-  runAutomodOnAntiraidLevel(pluginData, newLevel, user);
+  runAutomodOnAntiraidLevel(pluginData, newLevel, oldLevel, user);
 
   const logs = pluginData.getPlugin(LogsPlugin);
 

--- a/backend/src/plugins/Automod/triggers/antiraidLevel.ts
+++ b/backend/src/plugins/Automod/triggers/antiraidLevel.ts
@@ -7,6 +7,7 @@ interface AntiraidLevelTriggerResult {}
 export const AntiraidLevelTrigger = automodTrigger<AntiraidLevelTriggerResult>()({
   configType: t.type({
     level: tNullable(t.string),
+    only_on_change: tNullable(t.boolean),
   }),
 
   defaultConfig: {},
@@ -17,6 +18,14 @@ export const AntiraidLevelTrigger = automodTrigger<AntiraidLevelTriggerResult>()
     }
 
     if (context.antiraid.level !== triggerConfig.level) {
+      return;
+    }
+
+    if (
+      triggerConfig.only_on_change &&
+      context.antiraid.oldLevel !== undefined &&
+      context.antiraid.level === context.antiraid.oldLevel
+    ) {
       return;
     }
 

--- a/backend/src/plugins/Automod/types.ts
+++ b/backend/src/plugins/Automod/types.ts
@@ -130,6 +130,7 @@ export interface AutomodContext {
   };
   antiraid?: {
     level: string | null;
+    oldLevel?: string | null;
   };
   threadChange?: {
     created?: ThreadChannel;


### PR DESCRIPTION
Right now, the automod trigger `antiraid_level` runs any time the antiraid level is updated, even if it's value isn't changing (for example, `high` -> `high`). This adds an option `only_on_change` to disable that behavior, making it only run the rule if the value is actually changing (`off` -> `high`, `low` -> `high`, NOT `high` -> `high`).