### PR TITLE
fix parsing of file extension in match_attachment_type trigger

### DIFF
--- a/backend/src/plugins/Automod/triggers/matchAttachmentType.ts
+++ b/backend/src/plugins/Automod/triggers/matchAttachmentType.ts
@@ -1,5 +1,6 @@
 import { escapeInlineCode, Snowflake } from "discord.js";
 import * as t from "io-ts";
+import { extname } from "path";
 import { asSingleLine, messageSummary, verboseChannelMention } from "../../../utils";
 import { automodTrigger } from "../helpers";
 
@@ -33,7 +34,7 @@ export const MatchAttachmentTypeTrigger = automodTrigger<MatchResultType>()({
     }
 
     for (const attachment of context.message.data.attachments) {
-      const attachmentType = attachment.url.split(".").pop()!.toLowerCase();
+      const attachmentType = extname(new URL(attachment.url).pathname).slice(1).toLowerCase();
 
       const blacklist = trigger.blacklist_enabled
         ? (trigger.filetype_blacklist || []).map((_t) => _t.toLowerCase())


### PR DESCRIPTION
Discord attachment URLs now have a query string at the end
e.g. `https://cdn.discordapp.com/attachments/509738505241493515/1149102933129044079/zenyatta.jpg?ex=64fa4901&is=64f8f781&hm=f20463b7174e25f4bec8d1e6d7201275ebfd1ee62d11fe022b63429c4d4ac9f6&`

Fixes ZDEV-33