### PR TITLE
Add missing dependency to mutes plugin & fix timeout expiry

### DIFF
--- a/backend/src/data/Mutes.ts
+++ b/backend/src/data/Mutes.ts
@@ -8,7 +8,7 @@ import { Mute } from "./entities/Mute";
 
 const OLD_EXPIRED_MUTE_THRESHOLD = 7 * DAYS;
 
-export const MAX_TIMEOUT_DURATION = 28 * DAYS;
+export const MAX_TIMEOUT_DURATION = 27 * DAYS;
 // When a timeout is under this duration but the mute expires later, the timeout will be reset to max duration
 export const TIMEOUT_RENEWAL_THRESHOLD = 21 * DAYS;
 

--- a/backend/src/plugins/Mutes/MutesPlugin.ts
+++ b/backend/src/plugins/Mutes/MutesPlugin.ts
@@ -8,6 +8,7 @@ import { GuildMutes } from "../../data/GuildMutes";
 import { makeIoTsConfigParser, mapToPublicFn } from "../../pluginUtils";
 import { CasesPlugin } from "../Cases/CasesPlugin";
 import { LogsPlugin } from "../Logs/LogsPlugin";
+import { RoleManagerPlugin } from "../RoleManager/RoleManagerPlugin.js";
 import { zeppelinGuildPlugin } from "../ZeppelinPluginBlueprint";
 import { ClearBannedMutesCmd } from "./commands/ClearBannedMutesCmd";
 import { ClearMutesCmd } from "./commands/ClearMutesCmd";
@@ -68,7 +69,7 @@ export const MutesPlugin = zeppelinGuildPlugin<MutesPluginType>()({
     configSchema: ConfigSchema,
   },
 
-  dependencies: () => [CasesPlugin, LogsPlugin],
+  dependencies: () => [CasesPlugin, LogsPlugin, RoleManagerPlugin],
   configParser: makeIoTsConfigParser(ConfigSchema),
   defaultOptions,
 

--- a/backend/src/plugins/Mutes/functions/muteUser.ts
+++ b/backend/src/plugins/Mutes/functions/muteUser.ts
@@ -44,6 +44,7 @@ export async function muteUser(
   const muteType = getDefaultMuteType(pluginData);
   const muteExpiresAt = muteTime ? Date.now() + muteTime : null;
   const timeoutUntil = getTimeoutExpiryTime(muteExpiresAt);
+  console.log("timeoutUntil", timeoutUntil, muteTime);
 
   // No mod specified -> mark Zeppelin as the mod
   if (!muteOptions.caseArgs?.modId) {

--- a/backend/src/plugins/Mutes/functions/muteUser.ts
+++ b/backend/src/plugins/Mutes/functions/muteUser.ts
@@ -44,7 +44,6 @@ export async function muteUser(
   const muteType = getDefaultMuteType(pluginData);
   const muteExpiresAt = muteTime ? Date.now() + muteTime : null;
   const timeoutUntil = getTimeoutExpiryTime(muteExpiresAt);
-  console.log("timeoutUntil", timeoutUntil, muteTime);
 
   // No mod specified -> mark Zeppelin as the mod
   if (!muteOptions.caseArgs?.modId) {


### PR DESCRIPTION
Missing dependency currently causes a failure to unmute if RoleManager isnt loaded by anything otherwise

And timeout expiry of 28 days can cause a weird edge-case where timeouts will fail due to it being the same as the API limit, probably with time drift idk