### PR TITLE
automod match_link fixes

### DIFF
--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -647,7 +647,9 @@ export function getUrlsInString(str: string, onlyUnique = false): MatchedURL[] {
       return urls;
     }
 
-    const hostnameParts = matchUrl.hostname.split(".");
+    const hostname = matchUrl.hostname.endsWith(".") ? matchUrl.hostname.slice(0, -1) : matchUrl.hostname;
+
+    const hostnameParts = hostname.split(".");
     const tld = hostnameParts[hostnameParts.length - 1];
     if (tlds.includes(tld)) {
       urls.push(matchUrl);

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -625,6 +625,7 @@ const plainLinkRegex = /((?!https?:\/\/)\S)+\.\S+/; // anything.anything, withou
 // Both of the above, with precedence on the first one
 const urlRegex = new RegExp(`(${realLinkRegex.source}|${plainLinkRegex.source})`, "g");
 const protocolRegex = /^[a-z]+:\/\//;
+const hostnameTldRegex = /^[a-z]$/;
 
 interface MatchedURL extends URL {
   input: string;
@@ -647,7 +648,15 @@ export function getUrlsInString(str: string, onlyUnique = false): MatchedURL[] {
       return urls;
     }
 
-    const hostname = matchUrl.hostname.endsWith(".") ? matchUrl.hostname.slice(0, -1) : matchUrl.hostname;
+    //let hostname = matchUrl.hostname.endsWith(".") ? matchUrl.hostname.slice(0, -1) : matchUrl.hostname;
+    let hostname = matchUrl.hostname.toLowerCase();
+
+    if (hostname.length > 3) {
+      while (!hostnameTldRegex.test(hostname.at(-1)!)) {
+        if (!hostname.length) break;
+        hostname = hostname.slice(0, -1);
+      }
+    }
 
     const hostnameParts = hostname.split(".");
     const tld = hostnameParts[hostnameParts.length - 1];

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -648,7 +648,6 @@ export function getUrlsInString(str: string, onlyUnique = false): MatchedURL[] {
       return urls;
     }
 
-    //let hostname = matchUrl.hostname.endsWith(".") ? matchUrl.hostname.slice(0, -1) : matchUrl.hostname;
     let hostname = matchUrl.hostname.toLowerCase();
 
     if (hostname.length > 3) {

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -625,7 +625,6 @@ const plainLinkRegex = /((?!https?:\/\/)\S)+\.\S+/; // anything.anything, withou
 // Both of the above, with precedence on the first one
 const urlRegex = new RegExp(`(${realLinkRegex.source}|${plainLinkRegex.source})`, "g");
 const protocolRegex = /^[a-z]+:\/\//;
-const hostnameTldRegex = /^[a-z]$/;
 
 interface MatchedURL extends URL {
   input: string;
@@ -651,10 +650,7 @@ export function getUrlsInString(str: string, onlyUnique = false): MatchedURL[] {
     let hostname = matchUrl.hostname.toLowerCase();
 
     if (hostname.length > 3) {
-      while (!hostnameTldRegex.test(hostname.at(-1)!)) {
-        if (!hostname.length) break;
-        hostname = hostname.slice(0, -1);
-      }
+      hostname = hostname.replace(/[^a-z]+$/, "");
     }
 
     const hostnameParts = hostname.split(".");


### PR DESCRIPTION
Fixes ZDEV-64
Fixes ZDEV-66

## Why is this impl so cringe?
~~turns out im lazy. also i didnt want to touch the regex itself because i dont want to deal with potential new bypasses originated due to changing it. and it's also tricky since a non-encoded url can probably have `[]().` and still be valid~~