### PR TITLE
Reworked automod "set_slowmode" action

### DIFF
--- a/backend/src/plugins/Automod/actions/setSlowmode.ts
+++ b/backend/src/plugins/Automod/actions/setSlowmode.ts
@@ -1,4 +1,4 @@
-import { ChannelType, GuildTextBasedChannel, Snowflake, TextChannel, ThreadChannel } from "discord.js";
+import { ChannelType, GuildTextBasedChannel, Snowflake } from "discord.js";
 import * as t from "io-ts";
 import { convertDelayStringToMS, isDiscordAPIError, tDelayString, tNullable } from "../../../utils";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
@@ -16,15 +16,15 @@ export const SetSlowmodeAction = automodAction({
 
   async apply({ pluginData, actionConfig, contexts }) {
     const slowmodeMs = Math.max(actionConfig.duration ? convertDelayStringToMS(actionConfig.duration)! : 0, 0);
-    const channels = actionConfig.channels ?? new Array();
+    const channels: Snowflake[] = actionConfig.channels ?? [];
     if (channels.length === 0) {
-      channels.push(...contexts.filter(c => c.message?.channel_id).map(c => c.message!.channel_id));
+      channels.push(...contexts.filter((c) => c.message?.channel_id).map((c) => c.message!.channel_id));
     }
     for (const channelId of channels) {
       const channel = pluginData.guild.channels.cache.get(channelId as Snowflake);
-
       // Only text channels and text channels within categories support slowmodes
-      if (!channel || (!channel.isTextBased() && channel.type !== ChannelType.GuildCategory)) {
+
+      if (!channel?.isTextBased() && channel?.type !== ChannelType.GuildCategory) {
         continue;
       }
 

--- a/backend/src/plugins/Automod/actions/setSlowmode.ts
+++ b/backend/src/plugins/Automod/actions/setSlowmode.ts
@@ -1,4 +1,4 @@
-import { ChannelType, GuildTextBasedChannel, Snowflake } from "discord.js";
+import { ChannelType, GuildTextBasedChannel, Snowflake, TextChannel, ThreadChannel } from "discord.js";
 import * as t from "io-ts";
 import { convertDelayStringToMS, isDiscordAPIError, tDelayString, tNullable } from "../../../utils";
 import { LogsPlugin } from "../../Logs/LogsPlugin";
@@ -6,7 +6,7 @@ import { automodAction } from "../helpers";
 
 export const SetSlowmodeAction = automodAction({
   configType: t.type({
-    channels: t.array(t.string),
+    channels: tNullable(t.array(t.string)),
     duration: tNullable(tDelayString),
   }),
 
@@ -14,10 +14,13 @@ export const SetSlowmodeAction = automodAction({
     duration: "10s",
   },
 
-  async apply({ pluginData, actionConfig }) {
+  async apply({ pluginData, actionConfig, contexts }) {
     const slowmodeMs = Math.max(actionConfig.duration ? convertDelayStringToMS(actionConfig.duration)! : 0, 0);
-
-    for (const channelId of actionConfig.channels) {
+    const channels = actionConfig.channels ?? new Array();
+    if (channels.length === 0) {
+      channels.push(...contexts.filter(c => c.message?.channel_id).map(c => c.message!.channel_id));
+    }
+    for (const channelId of channels) {
       const channel = pluginData.guild.channels.cache.get(channelId as Snowflake);
 
       // Only text channels and text channels within categories support slowmodes


### PR DESCRIPTION
(Fixes #275)

Now if `channels` is empty or undefined it will set slowmode on the current channel, in terms of functionality I don't think there's any downgrade or loss, however without proper documentation/awareness I imagine this will create issues down the line of people not knowing how this works, similarly to how many other things on the bot are as of right now.

This is mostly for compatibility with #272 