### PR TITLE
remove erlpack

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "discord.js": "^14.11.0",
         "dotenv": "^4.0.0",
         "emoji-regex": "^8.0.0",
-        "erlpack": "github:discord/erlpack",
         "escape-string-regexp": "^1.0.5",
         "express": "^4.17.0",
         "fp-ts": "^2.0.1",
@@ -1551,14 +1550,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bit-twiddle": {
@@ -3467,16 +3458,6 @@
       "resolved": "https://registry.npmjs.org/env-string/-/env-string-1.0.1.tgz",
       "integrity": "sha512-/DhCJDf5DSFK32joQiWRpWrT0h7p3hVQfMKxiBb7Nt8C8IF8BYyPtclDnuGGLOoj16d/8udKeiE7JbkotDmorQ=="
     },
-    "node_modules/erlpack": {
-      "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/discord/erlpack.git#cbe76be04c2210fc9cb6ff95910f0937c1011d04",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.15.0"
-      }
-    },
     "node_modules/es5-ext": {
       "version": "0.10.62",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
@@ -3940,11 +3921,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,7 +38,6 @@
     "discord.js": "^14.11.0",
     "dotenv": "^4.0.0",
     "emoji-regex": "^8.0.0",
-    "erlpack": "github:discord/erlpack",
     "escape-string-regexp": "^1.0.5",
     "express": "^4.17.0",
     "fp-ts": "^2.0.1",


### PR DESCRIPTION
discord.js no longer uses erlpack internally, so its dependency can be removed.