### PR TITLE
Fixing docker-compose lightweight migration workking_dir

### DIFF
--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -11,7 +11,7 @@ services:
       HOST_MODE: lightweight
     env_file:
       - .env
-    working_dir: /zeppelin
+    working_dir: /zeppelin/backend
     command: ["npm", "run", "migrate-prod"]
 
   api:


### PR DESCRIPTION
Working_dir was fixed in the docker-compose standalone but not in the lightweight version