### PR TITLE
Make getInviteCodesInString check codes with only 8 chars

### DIFF
--- a/backend/src/utils.test.ts
+++ b/backend/src/utils.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 import z from "zod";
-import { convertDelayStringToMS, convertMSToDelayString, getUrlsInString, zAllowedMentions } from "./utils.js";
+import { convertDelayStringToMS, convertMSToDelayString, getInviteCodesInString, getUrlsInString, zAllowedMentions } from "./utils.js";
 import { ErisAllowedMentionFormat } from "./utils/erisAllowedMentionsToDjsMentionOptions.js";
 
 type AssertEquals<TActual, TExpected> = TActual extends TExpected ? true : false;
@@ -55,3 +55,8 @@ test("tAllowedMentions matches Eris's AllowedMentions", (t) => {
   const typeTest: AssertEquals<TAllowedMentions, ErisAllowedMentionFormat> = true;
   t.pass();
 });
+
+test("getInviteCodesInString() : Try to get all real invite codes in a string", (t) => {
+  const codes = getInviteCodesInString("My first link is https://discord.gg/jyfP8grUe (wrong) and the second is https://discord.gg/jyfP8grU (real)");
+  t.is(codes.join(" "), "jyfP8grU");
+})

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -575,10 +575,10 @@ export function isNotNull<T>(value: T): value is Exclude<T, null | undefined> {
 // discord.gg/<code>
 // discord.com/friend-invite/<code>
 const quickInviteDetection =
-  /discord(?:app)?\.com\/(?:friend-)?invite\/([a-z0-9-]+)|discord\.gg\/(?:\S+\/)?([a-z0-9-]+)/gi;
+  /discord(?:app)?\.com\/(?:friend-)?invite\/([a-z0-9-]{8})|discord\.gg\/(?:\S+\/)?([a-z0-9-]{8})/gi;
 
 const isInviteHostRegex = /(?:^|\.)(?:discord.gg|discord.com|discordapp.com)$/i;
-const longInvitePathRegex = /^\/(?:friend-)?invite\/([a-z0-9-]+)$/i;
+const longInvitePathRegex = /^\/(?:friend-)?invite\/([a-z0-9-]{8})$/i;
 
 export function getInviteCodesInString(str: string): string[] {
   const inviteCodes: string[] = [];
@@ -605,7 +605,7 @@ export function getInviteCodesInString(str: string): string[] {
       // discord.gg/[anything/]<code>
       if (url.hostname === "discord.gg") {
         const parts = url.pathname.split("/").filter(Boolean);
-        return parts[parts.length - 1];
+        return parts[parts.length - 1].substring(0, 8);
       }
 
       // discord.com/invite/<code>[/anything]


### PR DESCRIPTION
When we're using the match_invite rule, the bot, in its regex, check a code without any limit but all Discord invites have 8 characters. So, to avoid a member who has added a random char at the end of the link, by accident, take a sanction, I added a limit directly in all RegEx and in a substring for the part who works with the URL split.