### PR TITLE
fix: wrong key for counter's counter_trigger rule name

### DIFF
--- a/backend/src/plugins/Counters/types.ts
+++ b/backend/src/plugins/Counters/types.ts
@@ -32,7 +32,7 @@ export const zTrigger = z
       .optional(),
   })
   .transform((val, ctx) => {
-    const ruleName = String(ctx.path[ctx.path.length - 2]).trim();
+    const ruleName = String(ctx.path[ctx.path.length - 1]).trim();
 
     let reverseCondition = val.reverse_condition;
     if (!reverseCondition) {
@@ -51,7 +51,7 @@ export const zTrigger = z
   });
 
 const zTriggerFromString = zBoundedCharacters(0, 100).transform((val, ctx) => {
-  const ruleName = String(ctx.path[ctx.path.length - 2]).trim();
+  const ruleName = String(ctx.path[ctx.path.length - 1]).trim();
   const parsedCondition = parseCounterConditionString(val);
   if (!parsedCondition) {
     ctx.addIssue({


### PR DESCRIPTION
It appears that the trigger name is "triggers" instead of the actual AutoMod rule name.

**Example**: ["counters", "nsfw_infractions", "triggers", "autoban", "condition"]

ctx.path.length - 2 returns "triggers" while it should be ctx.path.length -1 for the automod rule name.