### PR TITLE
fix: api routes

### DIFF
--- a/backend/src/api/start.ts
+++ b/backend/src/api/start.ts
@@ -28,10 +28,10 @@ app.use(multer().none());
 
 const rootRouter = express.Router();
 
-initAuth(app);
-initGuildsAPI(app);
-initArchives(app);
-initDocs(app);
+initAuth(rootRouter);
+initGuildsAPI(rootRouter);
+initArchives(rootRouter);
+initDocs(rootRouter);
 
 // Default route
 rootRouter.get("/", (req, res) => {


### PR DESCRIPTION
In order to keep the `/api` prefix