### PR TITLE
fix: tag schema to include `embeds` key

### DIFF
--- a/backend/src/plugins/Tags/types.ts
+++ b/backend/src/plugins/Tags/types.ts
@@ -6,7 +6,8 @@ import { GuildSavedMessages } from "../../data/GuildSavedMessages.js";
 import { GuildTags } from "../../data/GuildTags.js";
 import { zEmbedInput } from "../../utils.js";
 
-export const zTag = z.union([z.string(), zEmbedInput]);
+const zEmbeds = z.object({embeds: z.array(zEmbedInput)})
+export const zTag = z.union([z.string(), zEmbeds]);
 export type TTag = z.infer<typeof zTag>;
 
 export const zTagCategory = z


### PR DESCRIPTION
during the io-ts to zod migration, there appears to have been a mistake where the `embeds` key wasn't included in the schema, causing an error when parsing it to a message object