### PR TITLE
fix: add updated mutes without a reason to the case log

### DIFF
--- a/backend/src/plugins/Mutes/functions/muteUser.ts
+++ b/backend/src/plugins/Mutes/functions/muteUser.ts
@@ -245,7 +245,7 @@ export async function muteUser(
   if (theCase) {
     // Update old case
     const noteDetails = [`Mute updated to ${muteTime ? timeUntilUnmuteStr : "indefinite"}`];
-    const reasons = reason ? [reason] : [];
+    const reasons = reason ? [reason] : ["No reason specified"];
     if (muteOptions.caseArgs?.extraNotes) {
       reasons.push(...muteOptions.caseArgs.extraNotes);
     }


### PR DESCRIPTION
previously, when updating a mute, if you didn't add a reason, it wouldn't show up in the case logs (or case info).