### PR TITLE
Update Client Events

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -274,7 +274,7 @@ connect().then(async () => {
     }
   });
 
-  client.on("error", (err) => {
+  client.on(Events.Error, (err) => {
     errorHandler(new DiscordJSError(err.message, (err as any).code, 0));
   });
 
@@ -371,7 +371,7 @@ connect().then(async () => {
     },
   });
 
-  client.once("ready", () => {
+  client.once(Events.ClientReady, () => {
     startUptimeCounter();
   });
 


### PR DESCRIPTION
Changed client event "ready" and "error" to use the Events import as the "ready" will be replaced by "clientReady" in v15 of discord.js.

https://v15.discordjs.guide/additional-info/updating-from-v14.html#client