### PR TITLE
feat: add icon_url to the author in embeds

### DIFF
--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -262,6 +262,7 @@ export const zEmbedInput = z.object({
       z.object({
         name: z.string(),
         url: z.string().optional(),
+        icon_url: z.string().optional(),
         width: z.number().optional(),
         height: z.number().optional(),
       }),


### PR DESCRIPTION
i don't really see why this didn't exist already
from a quick search in the discord I can see that it did but was removed at some point