### PR TITLE
fix: delete-days not applied when banning

### DIFF
--- a/backend/src/plugins/ModActions/commands/ban/BanMsgCmd.ts
+++ b/backend/src/plugins/ModActions/commands/ban/BanMsgCmd.ts
@@ -72,6 +72,7 @@ export const BanMsgCmd = modActionsMsgCmd({
       member,
       mod,
       contactMethods,
+      args["delete-days"] ?? undefined,
     );
   },
 });

--- a/backend/src/plugins/ModActions/commands/ban/BanSlashCmd.ts
+++ b/backend/src/plugins/ModActions/commands/ban/BanSlashCmd.ts
@@ -95,6 +95,7 @@ export const BanSlashCmd = modActionsSlashCmd({
       interaction.member as GuildMember,
       mod,
       contactMethods,
+      options["delete-days"] ?? undefined,
     );
   },
 });


### PR DESCRIPTION
Pass the `delete-days` arg from `BanMsgCmd` to `actualBanCmd`