### PR TITLE
Fix: Filter numeric enum keys from case type slash command options

### DIFF
--- a/backend/src/plugins/ModActions/commands/addcase/AddCaseSlashCmd.ts
+++ b/backend/src/plugins/ModActions/commands/addcase/AddCaseSlashCmd.ts
@@ -28,7 +28,9 @@ export const AddCaseSlashCmd = modActionsSlashCmd({
       name: "type",
       description: "The type of case to add",
       required: true,
-      choices: Object.keys(CaseTypes).map((type) => ({ name: type, value: type })),
+      choices: Object.keys(CaseTypes)
+        .filter((key) => isNaN(Number(key)))
+        .map((key) => ({ name: key, value: key })),
     }),
     slashOptions.user({ name: "user", description: "The user to add a case to", required: true }),
 


### PR DESCRIPTION
Fixes numeric enum values showing in `/addcase` options by filtering `Object.keys(CaseTypes)` to exclude reverse mappings.