### PR TITLE
fix: Remove reason requirement from slash unban command for consistency

### DIFF
--- a/backend/src/plugins/ModActions/commands/unban/UnbanSlashCmd.ts
+++ b/backend/src/plugins/ModActions/commands/unban/UnbanSlashCmd.ts
@@ -28,12 +28,6 @@ export const UnbanSlashCmd = modActionsSlashCmd({
     await interaction.deferReply({ ephemeral: true });
     const attachments = retrieveMultipleOptions(NUMBER_ATTACHMENTS_CASE_CREATION, options, "attachment");
 
-    if ((!options.reason || options.reason.trim() === "") && attachments.length < 1) {
-      pluginData.state.common.sendErrorMessage(interaction, "Text or attachment required", undefined, undefined, true);
-
-      return;
-    }
-
     let mod = interaction.member as GuildMember;
     const canActAsOther = await hasPermission(pluginData, "can_act_as_other", {
       channel: interaction.channel,


### PR DESCRIPTION
Removes the reason/attachment requirement validation from the slash unban command to match the existing behavior of the message unban command