### PR TITLE
feat: Add custom add_message and remove_message support to role buttons

### DIFF
--- a/backend/src/plugins/RoleButtons/types.ts
+++ b/backend/src/plugins/RoleButtons/types.ts
@@ -44,6 +44,8 @@ const zRoleButtonsConfigItem = z
         content: zMessageContent,
       }),
     ]),
+    add_message: zMessageContent.optional(),
+    remove_message: zMessageContent.optional(),
     options: z.array(zRoleButtonOption).max(25),
     exclusive: z.boolean().default(false),
   })


### PR DESCRIPTION
Adds support for custom `add_message` and `remove_message` configuration options to role buttons, allowing to customize the messages shown to users when roles are added or removed.
