### PR TITLE
Remove -sh flag from prefix !case command

### DIFF
--- a/backend/src/plugins/ModActions/commands/case/CaseMsgCmd.ts
+++ b/backend/src/plugins/ModActions/commands/case/CaseMsgCmd.ts
@@ -2,10 +2,6 @@ import { commandTypeHelpers as ct } from "../../../../commandTypes.js";
 import { modActionsMsgCmd } from "../../types.js";
 import { actualCaseCmd } from "./actualCaseCmd.js";
 
-const opts = {
-  show: ct.switchOption({ def: false, shortcut: "sh" }),
-};
-
 export const CaseMsgCmd = modActionsMsgCmd({
   trigger: "case",
   permission: "can_view",
@@ -14,12 +10,10 @@ export const CaseMsgCmd = modActionsMsgCmd({
   signature: [
     {
       caseNumber: ct.number(),
-
-      ...opts,
     },
   ],
 
   async run({ pluginData, message: msg, args }) {
-    actualCaseCmd(pluginData, msg, msg.author.id, args.caseNumber, args.show);
+    actualCaseCmd(pluginData, msg, msg.author.id, args.caseNumber);
   },
 });

--- a/backend/src/plugins/ModActions/commands/case/actualCaseCmd.ts
+++ b/backend/src/plugins/ModActions/commands/case/actualCaseCmd.ts
@@ -9,7 +9,7 @@ export async function actualCaseCmd(
   context: Message | ChatInputCommandInteraction,
   authorId: string,
   caseNumber: number,
-  show: boolean | null,
+  show?: boolean | null,
 ) {
   const theCase = await pluginData.state.cases.findByCaseNumber(caseNumber);
 


### PR DESCRIPTION
this flag didn’t change anything in prefix commands, responses are always public anyway. just cleaning it up so it's not confusing or pretending to be useful